### PR TITLE
Update passport-google-oauth20 to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "server": "nodemon index.js --ignore tests",
     "client": "npm run start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
-    "build":
-      "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run build --prefix client",
+    "build": "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run build --prefix client",
     "heroku-postbuild": "npm run build"
   },
   "author": "",
@@ -25,7 +24,7 @@
     "mongoose": "^4.11.1",
     "nodemon": "^1.11.0",
     "passport": "^0.3.2",
-    "passport-google-oauth20": "^1.0.0",
+    "passport-google-oauth20": "^2.0.0",
     "path-parser": "^2.0.2",
     "puppeteer": "^1.0.0",
     "redis": "^2.8.0",


### PR DESCRIPTION
The 1.0.0 version of passport-google-oauth20 relies on a deprecated API, and it's tripping up everyone who takes this course. This pull request solves the issue. 